### PR TITLE
Wrong package name for python

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -28,7 +28,7 @@ echo "deb https://dl.cloudsmith.io/public/openhd/openhd-2-1-testing/deb/${OS} ${
 
 apt -y update || exit 1
 
-apt -y install libboost-regex-dev libasio-dev libboost-filesystem-dev libboost-system-dev libboost-program-options-dev lifepoweredpi openhd python2 python-lxml || exit 1
+apt -y install libboost-regex-dev libasio-dev libboost-filesystem-dev libboost-system-dev libboost-program-options-dev lifepoweredpi openhd python python-lxml || exit 1
 
 curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py
 


### PR DESCRIPTION
The previous PR had an incorrect package name for python.